### PR TITLE
Fix keeper leader election

### DIFF
--- a/helm/keeper-sts/Chart.yaml
+++ b/helm/keeper-sts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: keeper-sts
 description: A Helm chart for setting up ClickHouse Keeper using StatefulSet
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.16.0"

--- a/helm/keeper-sts/templates/chk.yaml
+++ b/helm/keeper-sts/templates/chk.yaml
@@ -54,6 +54,7 @@ data:
   keeper_config.xml: |
     <clickhouse>
         <include_from>/tmp/clickhouse-keeper/config.d/generated-keeper-settings.xml</include_from>
+        <path>/var/lib/clickhouse-keeper</path>
         <logger>
             <level>trace</level>
             <console>true</console>
@@ -61,7 +62,6 @@ data:
         <listen_host>{{ .Values.keeper.listen_host }}</listen_host>
         <keeper_server incl="keeper_server">
             <enable_reconfiguration>true</enable_reconfiguration>
-            <path>/var/lib/clickhouse-keeper</path>
             <tcp_port>{{ .Values.keeper.tcp_port }}</tcp_port>
             <four_letter_word_white_list>*</four_letter_word_white_list>
             <coordination_settings>

--- a/helm/keeper-sts/templates/chk.yaml
+++ b/helm/keeper-sts/templates/chk.yaml
@@ -145,7 +145,7 @@ data:
         echo "<server_id>${MY_ID}</server_id>"
         echo "<raft_configuration>"
         if [[ "0" == $(echo "${CURRENT_KEEPER_CONFIG}" | grep -c "${HOST}.${DOMAIN}") ]]; then
-          echo "<server><id>${MY_ID}</id><hostname>${HOST}.${DOMAIN}</hostname><port>${RAFT_PORT}</port><priority>1</priority><start_as_follower>true</start_as_follower></server>"
+          echo "<server><id>${MY_ID}</id><hostname>${HOST}.${DOMAIN}</hostname><port>${RAFT_PORT}</port><priority>1</priority></server>"
         fi
         while IFS= read -r line; do
           id=$(echo "$line" | cut -d '=' -f 1 | cut -d '.' -f 2)


### PR DESCRIPTION
Fixes two bugs:
- Keeper could not write to the /etc directory for compiling it's preprocessed configs
- No Keeper instances were allowed to become leader in clustered mode